### PR TITLE
Add an Automatic-Module-Name to MANIFEST.MF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,13 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
 					<version>3.2.2</version>
+					<configuration>
+						<archive>
+							<manifestEntries>
+								<Automatic-Module-Name>vldocking</Automatic-Module-Name>
+							</manifestEntries>
+						</archive>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -175,7 +182,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-                
+
                 <configuration>
                     <flattenMode>bom</flattenMode>
                 </configuration>
@@ -197,7 +204,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>        
+            </plugin>
 		</plugins>
 
 		<resources>


### PR DESCRIPTION
This way, the jar file can be more easily used in a modularized application.